### PR TITLE
corrects nine wordids from close_adj-nou to close_vrb in train set

### DIFF
--- a/data/train/close.tsv
+++ b/data/train/close.tsv
@@ -6,22 +6,22 @@
 "close"	"close_adj-nou"	"Each of the plantations are located either adjacent to, or in close proximity to the Congo River."	62	67
 "close"	"close_adj-nou"	"Single molecule localization with super-resolution imaging techniques requires the specific delivery of fluorophores into close proximity with a target protein."	122	127
 "close"	"close_adj-nou"	"This shows that until the 6th century these Christians had been in close contact with Alexandria."	67	72
-"close"	"close_adj-nou"	"NXP Semiconductors And Freescale Semiconductor Close Merger RTTNews."	47	52
+"close"	"close_vrb"	"NXP Semiconductors And Freescale Semiconductor Close Merger RTTNews."	47	52
 "close"	"close_adj-nou"	"He was followed there by one of his Facla subordinates and a close friend, Vlaicu Barna."	61	66
 "close"	"close_adj-nou"	"Up close : Carol Jerrems with Larry Clark, Nan Goldin and William Yang."	3	8
 "close"	"close_adj-nou"	"He was also a friend and close adviser to New York City Mayor Fiorello LaGuardia."	25	30
 "close"	"close_adj-nou"	"During this time MacPherson resided in Notting Hill with close friend Robbie Williams."	57	62
 "close"	"close_vrb"	"Postflight investigation found that the oxidizer isolation valve had failed to close after the first burn."	79	84
-"close"	"close_adj-nou"	"This time, Woolley held his side together with 76 and they were 172 for five at the close."	84	89
+"close"	"close_vrb"	"This time, Woolley held his side together with 76 and they were 172 for five at the close."	84	89
 "close"	"close_adj-nou"	"It is very close to Perambur and Perambur Carriage Works Railway Stations."	11	16
 "close"	"close_adj-nou"	"During sexual reproduction, mating with a close relative (inbreeding) often leads to inbreeding depression."	42	47
 "close"	"close_adj-nou"	"Close-range anti-submarine defense was provided by two twin 12.75-inch (324 mm) Mk 32 torpedo tubes."	0	5
-"close"	"close_adj-nou"	"In June 2010 it was announced that the Museum would close because of Lincolnshire County Council cuts."	52	57
+"close"	"close_vrb"	"In June 2010 it was announced that the Museum would close because of Lincolnshire County Council cuts."	52	57
 "close"	"close_adj-nou"	"An extreme close up lets the detail of the scratching be more easily seen."	11	16
 "close"	"close_adj-nou"	"Smoothness is a measure of how similar colors that are close together are."	55	60
 "close"	"close_adj-nou"	"There is a small stadium, called Waldstadion, close to the Domholzschule."	46	51
 "close"	"close_adj-nou"	"The Persian onager is listed as critically endangered by IUCN Red List, as it is close to extinction."	81	86
-"close"	"close_adj-nou"	"Ferrybridge and Eggborough power stations were scheduled to close in March 2016."	60	65
+"close"	"close_vrb"	"Ferrybridge and Eggborough power stations were scheduled to close in March 2016."	60	65
 "close"	"close_adj-nou"	"The regional checkoff is within their state or very close to the state."	52	57
 "close"	"close_adj-nou"	"In Carinthia similar policy was conducted by Wilhelm Schick, Gauleiter's close associate."	73	78
 "close"	"close_vrb"	"In June 2010, the hospital announced it would close on July 2, 2010, and file for bankruptcy."	46	51
@@ -32,7 +32,7 @@
 "close"	"close_adj-nou"	"It is located in close proximity to the Playa de Los Ladrillos."	17	22
 "close"	"close_vrb"	"Indianapolis would close out the half quarterback Peyton Manning completing a 3-yard touchdown pass to tight end Dallas Clark."	19	24
 "close"	"close_adj-nou"	"She and Arnold also had close friends who were either actively Loyalist or sympathetic to that cause."	24	29
-"close"	"close_adj-nou"	"Blue doors close at the end of the current wave of enemies, but green ones remain open."	11	16
+"close"	"close_vrb"	"Blue doors close at the end of the current wave of enemies, but green ones remain open."	11	16
 "close"	"close_adj-nou"	"Anecdotal evidence indicates that nobody would show a bid anywhere close to that consensus level."	67	72
 "close"	"close_adj-nou"	"Ever since Emmett's death she had a close relationship with many African-American media outlets."	36	41
 "close"	"close_adj-nou"	"The Llenlleney'ten are mostly Secwepemc ethnically, but have close family ties and shared cultural traditions with the Tsilhqot'in."	61	66
@@ -51,14 +51,14 @@
 "close"	"close_adj-nou"	"Colston's is located at the top of Bell Hill, a road running close to the M32 motorway."	61	66
 "close"	"close_adj-nou"	"Recent research by Peder Anker has suggested a close theoretical relationship between Tansley's ecology and his psychology."	47	52
 "close"	"close_adj-nou"	"Gelotia is close to the salticid genera Cocalus and Mintonia."	11	16
-"close"	"close_adj-nou"	"At the close of each episode, Burnett tugged her ear."	7	12
+"close"	"close_vrb"	"At the close of each episode, Burnett tugged her ear."	7	12
 "close"	"close_adj-nou"	"He spent time at the Institute for the Harmonious Development of Man and became a close student of Gurdjieff."	82	87
 "close"	"close_adj-nou"	"While Syaoran's feelings quickly developed into romantic, Sakura remained naive and simply thought of him as a close friend."	111	116
 "close"	"close_adj-nou"	"Penllergar primary school is very near the church in fact so close by it will take three minutes."	61	66
 "close"	"close_adj-nou"	"Nunnery Colliery was a coal mine close to the city centre of Sheffield, South Yorkshire."	33	38
 "close"	"close_adj-nou"	"Those manoeuvres were to reach other planets also orbiting close to the ecliptic, so they were mostly in-plane changes."	59	64
 "close"	"close_adj-nou"	"It is close to Newlands Stadium, which is a rugby union and football venue."	6	11
-"close"	"close_adj-nou"	"In May 2010 Cardiff University announced that the Academy would close because of a lack of funds."	64	69
+"close"	"close_vrb"	"In May 2010 Cardiff University announced that the Academy would close because of a lack of funds."	64	69
 "close"	"close_vrb"	"Street's health and pitching improved, although Ziegler continued to close."	69	74
 "close"	"close_adj-nou"	"His death went unnoticed in the media and was quietly buried in Islamabad with close family members attending his funeral."	79	84
 "close"	"close_adj-nou"	"After giving birth, the mother stays close to the pups in the den, while the rest of the pack hunts."	37	42
@@ -66,8 +66,8 @@
 "close"	"close_adj-nou"	"Simpson lost a very close points decision as referee Phil Edwards scored the bout 115-114 in favour of Williams."	20	25
 "close"	"close_adj-nou"	"Judge's Hill stands close to the Hag or Bowhill Burn."	20	25
 "close"	"close_adj-nou"	"While highly violent and skilled in close quarters combat, he does not allow drug use or sales within his gang."	36	41
-"close"	"close_adj-nou"	"It is designated ""Trap Town"" at the close of the 18th century by Griffith (1795)."	36	41
-"close"	"close_adj-nou"	"In essence the show came to life just as its run drew to a close."	59	64
+"close"	"close_vrb"	"It is designated ""Trap Town"" at the close of the 18th century by Griffith (1795)."	36	41
+"close"	"close_vrb"	"In essence the show came to life just as its run drew to a close."	59	64
 "close"	"close_adj-nou"	"Kusgoan is towards the South East of Lonavla City.Very close to Mumbai- Pune Expresway."	55	60
 "close"	"close_adj-nou"	"We are not anywhere close to the age the Beatles were."	20	25
 "close"	"close_adj-nou"	"Ezio also finds out that his close allies, Luis Santangel and Raphael Sanchez, are in fact Assassins themselves."	29	34


### PR DESCRIPTION
Some of these labeling errors may have occurred due to the use of POS in the wordids. For example, the sample "In essence the show came to life just as its run drew to a _close_," is currently labeled close_adj-nou/'kloʊs, which is corrected in this push to close_vrb/'kloʊz.