### PR TITLE
Correct the pronunciations of "upset"

### DIFF
--- a/data/eval/upset.tsv
+++ b/data/eval/upset.tsv
@@ -1,11 +1,11 @@
 "homograph"	"wordid"	"sentence"	"start"	"end"
 "upset"	"upset_vrb"	"These calculations were upset by the disaster of the 2004 Indian Ocean earthquake, which devastated six southern coastal provinces."	24	29
-"upset"	"upset_nou"	"After seeing how upset Susan is about the school, Ben admits that he started the fire."	17	22
-"upset"	"upset_nou"	"Upset and unaware of the reason for Mme Arnoux's absence, Frédéric sleeps with Rosanette instead."	0	5
-"upset"	"upset_nou"	"Upset by the massacre at the bar, Buscemi convinces El Mariachi to give up his quest for blood."	0	5
+"upset"	"upset_vrb"	"After seeing how upset Susan is about the school, Ben admits that he started the fire."	17	22
+"upset"	"upset_vrb"	"Upset and unaware of the reason for Mme Arnoux's absence, Frédéric sleeps with Rosanette instead."	0	5
+"upset"	"upset_vrb"	"Upset by the massacre at the bar, Buscemi convinces El Mariachi to give up his quest for blood."	0	5
 "upset"	"upset_nou"	"Arizona was nearly the victim of yet another upset, outlasting a 5-game match to Ohio."	45	50
-"upset"	"upset_nou"	"Casper became jealous and became very upset, causing him to ruin all Imogen's work making her very upset."	99	104
+"upset"	"upset_vrb"	"Casper became jealous and became very upset, causing him to ruin all Imogen's work making her very upset."	99	104
 "upset"	"upset_vrb"	"The first is that you were in a dead end because you upset everyone without satisfying Italy."	53	58
 "upset"	"upset_nou"	"Since the product was used only externally, there was no risk of stomach upset."	73	78
 "upset"	"upset_vrb"	"Brock was evidently upset by the news that the conspirators had been shot."	20	25
-"upset"	"upset_nou"	"Will liberals be upset with Tim Kaine?"	17	22
+"upset"	"upset_vrb"	"Will liberals be upset with Tim Kaine?"	17	22

--- a/data/train/upset.tsv
+++ b/data/train/upset.tsv
@@ -1,90 +1,90 @@
 "homograph"	"wordid"	"sentence"	"start"	"end"
-"upset"	"upset_nou"	"Even the tabloid owner Dada (Rajpal Yadav) is upset with Jai and disapproves his idea of unraveling the truth."	46	51
+"upset"	"upset_vrb"	"Even the tabloid owner Dada (Rajpal Yadav) is upset with Jai and disapproves his idea of unraveling the truth."	46	51
 "upset"	"upset_vrb"	"Brode said that two years later rock and roll would similarly upset the American nation."	62	67
 "upset"	"upset_nou"	"Unable to revive him, the girl throws the potion away in her upset."	61	66
-"upset"	"upset_nou"	"In addition to the sex scene, the MPAA were also upset with a puppet being eaten alive by sharks."	49	54
-"upset"	"upset_nou"	"Duncan attempts to kiss Susanna, but she moves away, which makes him become even more upset."	86	91
-"upset"	"upset_nou"	"Durham's leaders were upset and he was rumored to have been disciplined."	22	27
-"upset"	"upset_nou"	"When Lee crossed the river untouched on July 14, Lincoln and Stanton were upset."	74	79
+"upset"	"upset_vrb"	"In addition to the sex scene, the MPAA were also upset with a puppet being eaten alive by sharks."	49	54
+"upset"	"upset_vrb"	"Duncan attempts to kiss Susanna, but she moves away, which makes him become even more upset."	86	91
+"upset"	"upset_vrb"	"Durham's leaders were upset and he was rumored to have been disciplined."	22	27
+"upset"	"upset_vrb"	"When Lee crossed the river untouched on July 14, Lincoln and Stanton were upset."	74	79
 "upset"	"upset_vrb"	"In the playoffs, the Rangers were upset by the Syracuse Crunch in the first round."	34	39
-"upset"	"upset_nou"	"Once everyone is gone she is shown to be physically upset by everything just happened."	52	57
+"upset"	"upset_vrb"	"Once everyone is gone she is shown to be physically upset by everything just happened."	52	57
 "upset"	"upset_vrb"	"As the fifteenth seed, she was upset in the first round by unseeded Francoise Abanda in two tie breaks."	31	36
-"upset"	"upset_nou"	"Rictor is upset with the news but forgives Rahne when he learns that she just worries about his soul."	10	15
-"upset"	"upset_nou"	"We were quite upset but at that time, it was too late to change it."""	14	19
-"upset"	"upset_nou"	"Becoming guilty when one acts against justice or upset when someone else acts unjustly."	49	54
-"upset"	"upset_nou"	"Mary Moore and her children were extremely close, and Mary and Marianne were especially upset by John's actions."	88	93
-"upset"	"upset_nou"	"He is very upset as he had said he wanted to ask her that even before she was his tutor."	11	16
+"upset"	"upset_vrb"	"Rictor is upset with the news but forgives Rahne when he learns that she just worries about his soul."	10	15
+"upset"	"upset_vrb"	"We were quite upset but at that time, it was too late to change it."""	14	19
+"upset"	"upset_vrb"	"Becoming guilty when one acts against justice or upset when someone else acts unjustly."	49	54
+"upset"	"upset_vrb"	"Mary Moore and her children were extremely close, and Mary and Marianne were especially upset by John's actions."	88	93
+"upset"	"upset_vrb"	"He is very upset as he had said he wanted to ask her that even before she was his tutor."	11	16
 "upset"	"upset_nou"	"Other resistance welding methods include butt welding, flash welding, projection welding, and upset welding."	94	99
 "upset"	"upset_vrb"	"He upset world #4 Errol Zimmerman at the opening stage, taking a decision."	3	8
 "upset"	"upset_nou"	"In a surprise upset at the National Championships, Frater was beaten into second place in the 100 m final."	14	19
 "upset"	"upset_nou"	"In a startling upset, Mandell lost the crown when he was KOed by Al Singer in the first round."	15	20
-"upset"	"upset_nou"	"Eve is upset and goes to France to sort out her divorce."	7	12
-"upset"	"upset_nou"	"Bad employees aren't upset about this, because they get a free ride from the hard work of the good employees."	21	26
-"upset"	"upset_nou"	"Business acquaintances are upset because Lash might shut down clubs like theirs if elected DA."	27	32
-"upset"	"upset_nou"	"Back at their camp, they see a blonde woman upset over their dead gators."	44	49
+"upset"	"upset_vrb"	"Eve is upset and goes to France to sort out her divorce."	7	12
+"upset"	"upset_vrb"	"Bad employees aren't upset about this, because they get a free ride from the hard work of the good employees."	21	26
+"upset"	"upset_vrb"	"Business acquaintances are upset because Lash might shut down clubs like theirs if elected DA."	27	32
+"upset"	"upset_vrb"	"Back at their camp, they see a blonde woman upset over their dead gators."	44	49
 "upset"	"upset_vrb"	"The foundations of Genoshan society has been upset in recent years due to the efforts of outside mutant interests."	45	50
 "upset"	"upset_nou"	"Middlesbrough 3 Chelsea 0 (Premier League, 11 February 2006) (Report)A huge upset that turned heads all over England."	76	81
-"upset"	"upset_nou"	"Upset and angry, he leaves and goes on his motorcycle, returning home later that night."	0	5
-"upset"	"upset_nou"	"Feinsinger, too, was deeply upset by Wilson's remarks."	28	33
+"upset"	"upset_vrb"	"Upset and angry, he leaves and goes on his motorcycle, returning home later that night."	0	5
+"upset"	"upset_vrb"	"Feinsinger, too, was deeply upset by Wilson's remarks."	28	33
 "upset"	"upset_nou"	"It was the biggest surprise upset of the season with LMOB winning the Sevens and grand slam."	28	33
 "upset"	"upset_vrb"	"Ogle upset Walsh, winning the fight via unanimous decision."	5	10
 "upset"	"upset_nou"	"Teddy Bridgewater paces Louisville to stunning upset of Florida."	47	52
 "upset"	"upset_vrb"	"Unless stopped at once it is likely to upset the friendly relations existing between Australia and England."	39	44
-"upset"	"upset_nou"	"Jae-min passes the phone to Soo-jung and In-wook is upset that she stood him up for dinner."	52	57
+"upset"	"upset_vrb"	"Jae-min passes the phone to Soo-jung and In-wook is upset that she stood him up for dinner."	52	57
 "upset"	"upset_vrb"	"The Titans were upset by losing in the first round to the (Greensboro Whirlies) 35 to 41."	16	21
-"upset"	"upset_nou"	"However this upset and aroused suspicions among the Americans."	13	18
+"upset"	"upset_vrb"	"However this upset and aroused suspicions among the Americans."	13	18
 "upset"	"upset_nou"	"In 2002, the 24-year-old Reed challenged Representative Sara Steelman for the 62nd legislative district, winning an upset."	116	121
 "upset"	"upset_vrb"	"Under her guidance, he is able to upset Paulie Mitchell in his next fight, pleasing Papa and Julie both."	34	39
-"upset"	"upset_nou"	"Finkel was said to be very upset by this state of affairs."	27	32
+"upset"	"upset_vrb"	"Finkel was said to be very upset by this state of affairs."	27	32
 "upset"	"upset_vrb"	"In the second round, she upset 26th seed Anabel Medina Garrigues."	25	30
-"upset"	"upset_nou"	"In the Disney version, she is upset with Tiger Lily that Peter rescued."	30	35
-"upset"	"upset_nou"	"The Boov become astonished at Oh's plan, but Smek becomes upset and reminds everyone that he is the captain."	58	63
-"upset"	"upset_nou"	"He heads to Berlin, leaving behind an upset Marianna, who tells him not to return (""Paradise"")."	38	43
-"upset"	"upset_nou"	"Resignedly, the upset Baron accepts the romance between his wife and Camille, and the three leave together."	16	21
-"upset"	"upset_nou"	"After being beaten up by chav girls, he finds Cassie waiting at his house, upset he had stood her up."	75	80
+"upset"	"upset_vrb"	"In the Disney version, she is upset with Tiger Lily that Peter rescued."	30	35
+"upset"	"upset_vrb"	"The Boov become astonished at Oh's plan, but Smek becomes upset and reminds everyone that he is the captain."	58	63
+"upset"	"upset_vrb"	"He heads to Berlin, leaving behind an upset Marianna, who tells him not to return (""Paradise"")."	38	43
+"upset"	"upset_vrb"	"Resignedly, the upset Baron accepts the romance between his wife and Camille, and the three leave together."	16	21
+"upset"	"upset_vrb"	"After being beaten up by chav girls, he finds Cassie waiting at his house, upset he had stood her up."	75	80
 "upset"	"upset_nou"	"The 1993 renewal saw the biggest upset in Breeders' Cup history when the French-based Arcangues won at odds of 133-1."	33	38
 "upset"	"upset_nou"	"In a few cases, gastrointestinal upset, headaches, skin reactions, and dizziness were reported."	33	38
 "upset"	"upset_nou"	"However, in an upset, lawmakers chose not Leger as Speaker but New Iberia Republican Taylor Barras."	15	20
-"upset"	"upset_nou"	"Chinchillas are social animals and are likely to be upset to have their breeding mate changed in breeding season."	52	57
-"upset"	"upset_nou"	"They were upset that Chiang Kai-shek's rule was a personalistic dictatorship and that the Nationalists had ignored their democratic principles."	10	15
+"upset"	"upset_vrb"	"Chinchillas are social animals and are likely to be upset to have their breeding mate changed in breeding season."	52	57
+"upset"	"upset_vrb"	"They were upset that Chiang Kai-shek's rule was a personalistic dictatorship and that the Nationalists had ignored their democratic principles."	10	15
 "upset"	"upset_vrb"	"Several members of the band expressed concern over this version of the song, especially Slash, fearing it would upset Young."	112	117
 "upset"	"upset_vrb"	"Ravenel upset even more people after he apologized to mentally handicapped people for comparing them to the NAACP."	8	13
 "upset"	"upset_nou"	"In a surprising upset, the Knesset elected Katsav, by 63 to 57."	16	21
-"upset"	"upset_nou"	"Naomi reiterates that she's doing the right thing, though she seems to be upset about what she's done."	74	79
+"upset"	"upset_vrb"	"Naomi reiterates that she's doing the right thing, though she seems to be upset about what she's done."	74	79
 "upset"	"upset_vrb"	"Author Hugh M. Cole mentioned Bouck's platoon in passing, which upset platoon member William James (Tsakanikas)."	64	69
-"upset"	"upset_nou"	"Leilene got upset but tried not to cry so she would not look emotional."	12	17
-"upset"	"upset_nou"	"The girls, except Mandy, are in the dressing rooms and are upset that they are locked in."	59	64
+"upset"	"upset_vrb"	"Leilene got upset but tried not to cry so she would not look emotional."	12	17
+"upset"	"upset_vrb"	"The girls, except Mandy, are in the dressing rooms and are upset that they are locked in."	59	64
 "upset"	"upset_nou"	"In an upset, Yoho managed to unset Stearns, though Oelrich and Jett placed a distant third and fourth, respectively."	6	11
-"upset"	"upset_nou"	"Satan, upset at his injury, demands Death to send him to a hell hospital and ignores Sam entirely."	7	12
+"upset"	"upset_vrb"	"Satan, upset at his injury, demands Death to send him to a hell hospital and ignores Sam entirely."	7	12
 "upset"	"upset_vrb"	"One of Grindstone's foals, Birdstone, upset Smarty Jones to win the 2004 Belmont Stakes."	38	43
 "upset"	"upset_vrb"	"She upset Martina Hingis to win the women's singles title at the French Open in 1997."	4	9
 "upset"	"upset_nou"	"Cole's win was something of an upset."	31	36
 "upset"	"upset_nou"	"The Michigan Stadium crowd, sensing a major upset, began screaming and chanting."	44	49
-"upset"	"upset_nou"	"Libby and Drew break up, but Steph is upset when Drew admits he still loves Libby."	38	43
-"upset"	"upset_nou"	"Marta does not understand the situation and is very angry and upset."	62	67
+"upset"	"upset_vrb"	"Libby and Drew break up, but Steph is upset when Drew admits he still loves Libby."	38	43
+"upset"	"upset_vrb"	"Marta does not understand the situation and is very angry and upset."	62	67
 "upset"	"upset_vrb"	"In Houston, previously unbeaten (8-0-1) Rice hosted (6-3-0) Texas Christian (TCU) and was upset, 7-2."	90	95
 "upset"	"upset_vrb"	"The memory of her father's death begins to upset her studies and her relationships."	43	48
-"upset"	"upset_nou"	"Balarama was upset that they had been excluded for the marriage of their cousin Mitravinda."	13	18
+"upset"	"upset_vrb"	"Balarama was upset that they had been excluded for the marriage of their cousin Mitravinda."	13	18
 "upset"	"upset_vrb"	"Alcohol should be avoided, particularly as it can upset the stomach."	50	55
 "upset"	"upset_vrb"	"In December 2008, the UCR women's basketball team upset the #16-seeded Vanderbilt Commodores."	50	55
 "upset"	"upset_nou"	"In the 33rd round, Corinthians lost against América-MG, in a great upset."	68	73
-"upset"	"upset_nou"	"Epstein was upset, but Harrison placated him by saying, ""He may be late, but he'll be very clean."""	12	17
+"upset"	"upset_vrb"	"Epstein was upset, but Harrison placated him by saying, ""He may be late, but he'll be very clean."""	12	17
 "upset"	"upset_vrb"	"Scotland by contrast struggled, only managing draws with both opponents and coming close to being upset in both matches."	98	103
 "upset"	"upset_vrb"	"Dodd sometimes made unusual substitutions, as on a Saturday in Athens when Georgia Tech was about to be upset."	104	109
-"upset"	"upset_nou"	"He then comes back saying that he was upset because his wife just left him and he stays for dinner."	38	43
-"upset"	"upset_nou"	"Marshall becomes desperate, and Lily says he's really upset about not getting a new job."	54	59
+"upset"	"upset_vrb"	"He then comes back saying that he was upset because his wife just left him and he stays for dinner."	38	43
+"upset"	"upset_vrb"	"Marshall becomes desperate, and Lily says he's really upset about not getting a new job."	54	59
 "upset"	"upset_vrb"	"Sinatra became angry during Cohen's explanation and upset the table where Cohen was seated."	52	57
-"upset"	"upset_nou"	"They talk, and Jody being upset with her parents, tries to pressure sex on Kenny."	26	31
+"upset"	"upset_vrb"	"They talk, and Jody being upset with her parents, tries to pressure sex on Kenny."	26	31
 "upset"	"upset_vrb"	"At the French Open, Davenport was upset by the 22nd-ranked Dominique Van Roost in three sets in the first round."	34	39
-"upset"	"upset_nou"	"Devastated by this, Rachel departs, too upset to hear Jean's calls for her to come back."	40	45
-"upset"	"upset_nou"	"Eventually, JayJay, upset by feeling left out by his friends, decides to commit suicide in a local cavern."	20	25
+"upset"	"upset_vrb"	"Devastated by this, Rachel departs, too upset to hear Jean's calls for her to come back."	40	45
+"upset"	"upset_vrb"	"Eventually, JayJay, upset by feeling left out by his friends, decides to commit suicide in a local cavern."	20	25
 "upset"	"upset_nou"	"The team was finally defeated in 1909, via an upset by the Dayton Oakwoods in their final game of 1909."	46	51
-"upset"	"upset_nou"	"Stan is upset that no one cares about Rosie as a person anymore."	8	13
-"upset"	"upset_nou"	"Dellora Gates had long since resigned herself to her husband's all-night poker games, but many times became upset about them."	108	113
+"upset"	"upset_vrb"	"Stan is upset that no one cares about Rosie as a person anymore."	8	13
+"upset"	"upset_vrb"	"Dellora Gates had long since resigned herself to her husband's all-night poker games, but many times became upset about them."	108	113
 "upset"	"upset_nou"	"Galway produced a massive upset, beating Galway lifted their first Bob O'Keefe Cup ever."	26	31
-"upset"	"upset_nou"	"However, Bart also becomes upset with anti-Springfield sentiments coming from the neighboring town of Shelbyville."	27	32
+"upset"	"upset_vrb"	"However, Bart also becomes upset with anti-Springfield sentiments coming from the neighboring town of Shelbyville."	27	32
 "upset"	"upset_vrb"	"Li and Sun upset the favourites in Taicang."	11	16
-"upset"	"upset_nou"	"Seeing how upset Trevor is about this, Paul asks him to join him in his home town of Leeds."	11	16
+"upset"	"upset_vrb"	"Seeing how upset Trevor is about this, Paul asks him to join him in his home town of Leeds."	11	16
 "upset"	"upset_nou"	"The play proved vital in Tennessee's upset of South Carolina."	37	42
 "upset"	"upset_nou"	"When taking iron supplements, stomach upset and/or darkening of the feces are commonly experienced."	38	43
-"upset"	"upset_nou"	"Norris is upset about her affair and does not like Brendan."	10	15
+"upset"	"upset_vrb"	"Norris is upset about her affair and does not like Brendan."	10	15


### PR DESCRIPTION
The word "upset" should have the stress on the second syllable when it's an adjective, just like when it's a verb.